### PR TITLE
Preserve SemVer format for GitHub Actions versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,7 +49,8 @@
             "matchDepTypes": [
                 "action"
             ],
-            "pinDigests": false
+            "pinDigests": false,
+            "extractVersion": "^v(?<version>\\d+\\.\\d+\\.\\d+)$"
         }
     ]
 }


### PR DESCRIPTION
## What

Add `extractVersion` to the GitHub Actions packageRule in Renovate config to ensure version references maintain the `@vX.Y.Z` (SemVer) format.

## Why

When Renovate performs major updates for GitHub Actions, it converts the version format from `@v4.0.5` to `@v5` (major tag), losing the SemVer pinning (e.g., #56). By using `extractVersion` with a regex that captures the SemVer portion, Renovate will use `@v5.0.0` instead of `@v5`.