### PR TITLE
Fix GitHub Actions version resolution by restoring v prefix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,8 +49,7 @@
             "matchDepTypes": [
                 "action"
             ],
-            "pinDigests": false,
-            "extractVersion": "^v(?<version>\\d+\\.\\d+\\.\\d+)$"
+            "pinDigests": false
         }
     ]
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@6.0.2
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Pages
-        uses: actions/configure-pages@6.0.0
+        uses: actions/configure-pages@v6.0.0
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5.0.0
@@ -34,4 +34,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@5.0.0
+        uses: actions/deploy-pages@v5.0.0


### PR DESCRIPTION
## What

- Restore `v` prefix on GitHub Actions version tags in `deploy.yml` (`actions/checkout@v6.0.2`, `actions/configure-pages@v6.0.0`, `actions/deploy-pages@v5.0.0`)
- Remove `extractVersion` from Renovate config that was stripping the `v` prefix

## Why

After merging #59, the deploy workflow failed because Renovate had updated action versions without the `v` prefix (e.g., `actions/checkout@6.0.2` instead of `actions/checkout@v6.0.2`). GitHub Actions tags require the `v` prefix to resolve correctly.

The root cause was the `extractVersion: "^v(?<version>\\d+\\.\\d+\\.\\d+)$"` rule in `renovate.json`, which stripped `v` from extracted versions. Removing this rule and relying on the existing `:preserveSemverRanges` preset prevents recurrence.

Ref: https://github.com/Okabe-Junya/Okabe-Junya.github.io/actions/runs/25119905348/job/73617600561