### PR TITLE
Add robots.txt, sitemap.xml, and SEO meta tags to fix indexing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,16 +4,60 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Junya Okabe</title>
-    <meta name="description" content="Junya Okabe's personal profile page" />
+    <meta
+      name="description"
+      content="Junya Okabe — Software Engineer at Mercari, Inc. Interested in Platform Engineering, SRE, Kubernetes, CI/CD, and Go."
+    />
     <meta name="author" content="Junya Okabe" />
     <meta
       name="google-site-verification"
       content="pBY_2KTBL0nOGR8RCrXhwpoUd84gW3Ui5IXXinfT4yg"
     />
+    <link rel="canonical" href="https://okabe-junya.github.io/" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230d1117'/%3E%3Ctext x='50%25' y='54%25' font-family='system-ui,-apple-system,Segoe UI,Roboto,sans-serif' font-size='42' font-weight='700' fill='%23ffffff' text-anchor='middle' dominant-baseline='middle'%3EJ%3C/text%3E%3C/svg%3E"
+    />
     <meta property="og:title" content="Junya Okabe" />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://Okabe-Junya.github.io" />
+    <meta property="og:type" content="profile" />
+    <meta property="og:url" content="https://okabe-junya.github.io/" />
+    <meta
+      property="og:description"
+      content="Junya Okabe — Software Engineer at Mercari, Inc. Interested in Platform Engineering, SRE, Kubernetes, CI/CD, and Go."
+    />
+    <meta property="og:image" content="https://github.com/Okabe-Junya.png" />
+    <meta property="og:locale" content="en_US" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@junya__okabe" />
+    <meta name="twitter:creator" content="@junya__okabe" />
+    <meta name="twitter:title" content="Junya Okabe" />
+    <meta
+      name="twitter:description"
+      content="Software Engineer at Mercari, Inc. Platform Engineering, SRE, Kubernetes, CI/CD, Go."
+    />
+    <meta name="twitter:image" content="https://github.com/Okabe-Junya.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Junya Okabe",
+        "url": "https://okabe-junya.github.io/",
+        "image": "https://github.com/Okabe-Junya.png",
+        "jobTitle": "Software Engineer",
+        "worksFor": { "@type": "Organization", "name": "Mercari, Inc." },
+        "alumniOf": {
+          "@type": "CollegeOrUniversity",
+          "name": "University of Tsukuba"
+        },
+        "sameAs": [
+          "https://github.com/Okabe-Junya",
+          "https://twitter.com/junya__okabe",
+          "https://www.linkedin.com/in/junya-okabe/",
+          "https://www.wantedly.com/id/junya_okabe"
+        ]
+      }
+    </script>
   </head>
   <body>
     <h1>Junya Okabe</h1>

--- a/payment/index.html
+++ b/payment/index.html
@@ -2,6 +2,13 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230d1117'/%3E%3Ctext x='50%25' y='54%25' font-family='system-ui,-apple-system,Segoe UI,Roboto,sans-serif' font-size='42' font-weight='700' fill='%23ffffff' text-anchor='middle' dominant-baseline='middle'%3EJ%3C/text%3E%3C/svg%3E"
+    />
     <title>送金手段</title>
   </head>
   <body>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /payment/
+Disallow: /wishlist/
+
+Sitemap: https://okabe-junya.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://okabe-junya.github.io/</loc>
+    <lastmod>2026-05-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://okabe-junya.github.io/slide/</loc>
+    <lastmod>2026-05-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>

--- a/slide/index.html
+++ b/slide/index.html
@@ -3,7 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Self Introduction</title>
+    <title>Self Introduction — Junya Okabe</title>
+    <meta
+      name="description"
+      content="Self-introduction slide of Junya Okabe, Software Engineer at Mercari."
+    />
+    <link rel="canonical" href="https://okabe-junya.github.io/slide/" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230d1117'/%3E%3Ctext x='50%25' y='54%25' font-family='system-ui,-apple-system,Segoe UI,Roboto,sans-serif' font-size='42' font-weight='700' fill='%23ffffff' text-anchor='middle' dominant-baseline='middle'%3EJ%3C/text%3E%3C/svg%3E"
+    />
+    <meta property="og:title" content="Self Introduction — Junya Okabe" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://okabe-junya.github.io/slide/" />
+    <meta
+      property="og:description"
+      content="Self-introduction slide of Junya Okabe, Software Engineer at Mercari."
+    />
+    <meta property="og:image" content="https://github.com/Okabe-Junya.png" />
+    <meta name="twitter:card" content="summary" />
     <link rel="stylesheet" href="style.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/3.0.3/jspdf.umd.min.js"></script>

--- a/wishlist/index.html
+++ b/wishlist/index.html
@@ -2,6 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230d1117'/%3E%3Ctext x='50%25' y='54%25' font-family='system-ui,-apple-system,Segoe UI,Roboto,sans-serif' font-size='42' font-weight='700' fill='%23ffffff' text-anchor='middle' dominant-baseline='middle'%3EJ%3C/text%3E%3C/svg%3E"
+    />
     <meta
       http-equiv="refresh"
       content="0;url=https://www.amazon.jp/hz/wishlist/ls/R57YGCVEP5JA?ref_=wl_share"


### PR DESCRIPTION
## What

- Add `robots.txt` (disallowing `/payment/` and `/wishlist/`) and `sitemap.xml` listing the public pages.
- Add inline SVG favicon, canonical, OG/Twitter Card, and JSON-LD `Person` meta tags to `index.html`.
- Add `meta robots="noindex, nofollow"` to `payment/index.html` and `wishlist/index.html`.
- Add favicon and basic meta tags to `slide/index.html`.

## Why

Search Console showed two problems over the last 3 months:

- 46.67% of Googlebot requests returned 404, all from the Image bot — caused by missing favicon and `og:image`, which wasted crawl budget.
- 0 impressions, because there was no sitemap, no `robots.txt`, and minimal structured data.

`/payment/` (bank account info) and `/wishlist/` (Amazon redirect) should not appear in search results, so they are explicitly excluded.