### PR TITLE
Add minimal XML lint workflow and pin actions to commit SHA

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,12 +44,6 @@
             "addLabels": [
                 "renovate: patch"
             ]
-        },
-        {
-            "matchDepTypes": [
-                "action"
-            ],
-            "pinDigests": false
         }
     ]
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "."
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install xmllint
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libxml2-utils
+
       - name: Validate XML files
         run: |
           set -euo pipefail

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - "**/*.xml"
+      - ".github/workflows/lint.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "**/*.xml"
+      - ".github/workflows/lint.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  xml:
+    name: Validate XML
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate XML files
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find . -type f -name '*.xml' -not -path './.git/*')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No XML files found"
+            exit 0
+          fi
+          for f in "${files[@]}"; do
+            echo "::group::$f"
+            xmllint --noout "$f"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,21 +22,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install xmllint
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends libxml2-utils
-
       - name: Validate XML files
         run: |
-          set -euo pipefail
-          mapfile -t files < <(find . -type f -name '*.xml' -not -path './.git/*')
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "No XML files found"
-            exit 0
-          fi
-          for f in "${files[@]}"; do
-            echo "::group::$f"
-            xmllint --noout "$f"
-            echo "::endgroup::"
-          done
+          python3 <<'PY'
+          import os, sys
+          import xml.etree.ElementTree as ET
+          files = []
+          for root, dirs, fnames in os.walk('.'):
+              dirs[:] = [d for d in dirs if d != '.git']
+              files += [os.path.join(root, f) for f in fnames if f.endswith('.xml')]
+          if not files:
+              print('No XML files found'); sys.exit(0)
+          ok = True
+          for f in files:
+              try:
+                  ET.parse(f)
+                  print(f'OK   {f}')
+              except ET.ParseError as e:
+                  print(f'FAIL {f}: {e}'); ok = False
+          sys.exit(0 if ok else 1)
+          PY


### PR DESCRIPTION
## What

- Add `.github/workflows/lint.yml` that runs `xml.etree.ElementTree` (Python stdlib) against every `*.xml` file in PRs and pushes that touch XML.
- Pin every reusable action in `deploy.yml` and `lint.yml` to a commit SHA with a SemVer comment.
- Drop the `{ matchDepTypes: ["action"], pinDigests: false }` rule from `renovate.json` so Renovate maintains the SHA pins going forward.

## Why

- `sitemap.xml` is now part of the repo; a syntax error would silently break Google Search Console indexing on the next deploy.
- Python stdlib is preinstalled on `ubuntu-latest`, so the lint step needs no system package install and no third-party dependency.
- Pinning actions to a SHA with a SemVer comment is the standard supply-chain hardening pattern (prevents tag-rewriting attacks) while keeping Renovate able to bump versions. The previous `pinDigests: false` setting contradicted that policy and would have left newly added actions unpinned.