### PR TITLE
Add SRI integrity hashes to cdnjs scripts on slide page (closes #64)

### DIFF
--- a/slide/index.html
+++ b/slide/index.html
@@ -24,8 +24,18 @@
     <meta property="og:image" content="https://github.com/Okabe-Junya.png" />
     <meta name="twitter:card" content="summary" />
     <link rel="stylesheet" href="style.css" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/3.0.3/jspdf.umd.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"
+      integrity="sha384-ZZ1pncU3bQe8y31yfZdMFdSpttDoPmOZg2wguVK9almUodir1PghgT0eY7Mrty8H"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/3.0.3/jspdf.umd.min.js"
+      integrity="sha384-GwHhSt8QjC7J+v0zZ0Flfho/T76YHEcCL9w4rvjTIUHauh6gWJeBSIi3vWXxNhtA"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
   </head>
   <body>
     <!-- PC recommendation message (displayed only on smartphones) -->


### PR DESCRIPTION
## What

Add SHA-384 `integrity=` and `crossorigin=\"anonymous\"` to the `html2canvas` and `jspdf` script tags loaded from cdnjs on the slide page.

Hashes were computed from the pinned versions currently served:

```
html2canvas@1.4.1: sha384-ZZ1pncU3bQe8y31yfZdMFdSpttDoPmOZg2wguVK9almUodir1PghgT0eY7Mrty8H
jspdf@3.0.3:      sha384-GwHhSt8QjC7J+v0zZ0Flfho/T76YHEcCL9w4rvjTIUHauh6gWJeBSIi3vWXxNhtA
```

## Why

Without SRI, a compromise or accidental rebuild on cdnjs would silently execute on every slide visit. Adding integrity makes the browser refuse to run a script whose hash does not match the pinned value.

Closes #64